### PR TITLE
03 ページネーションの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'annotate'
 gem 'font-awesome-sass'
 gem 'carrierwave'
 gem 'faker'
+gem 'kaminari'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,18 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     jwt (2.2.1)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -281,6 +293,7 @@ DEPENDENCIES
   font-awesome-sass
   jbuilder (~> 2.5)
   jquery-rails
+  kaminari
   listen (>= 3.0.5, < 3.2)
   mysql2 (>= 0.4.4, < 0.6.0)
   popper_js

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -93,3 +93,7 @@ img {
     }
   }}
 
+.pagination {
+  justify-content: center;
+}
+

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -6,7 +6,12 @@ class PostsController < ApplicationController
     # SELECT `users`.* FROM `users` WHERE `users`.`id` IN (49, 48, 47, 46, 45, 44, 43, 42, 41, 40)
     # Post.all.order(created_at: :desc)だと以下のようなクエリが10回走る
     # SELECT  `users`.* FROM `users` WHERE `users`.`id` = 40 LIMIT 1
-    @posts = Post.all.includes(:user).order(created_at: :desc)
+    
+    # params[:page]が何ページ目であるか示す
+    # 例えば、paginationにて2ページ目を選択すると、params[:page]は2となる
+    # その場合、このクエリが走る => SELECT  `posts`.* FROM `posts` ORDER BY `posts`.`created_at` DESC LIMIT 10 OFFSET 10
+    # ３ページ目を選択すると、このクエリが走る => SELECT  `posts`.* FROM `posts` ORDER BY `posts`.`created_at` DESC LIMIT 10 OFFSET 20
+    @posts = Post.all.includes(:user).order(created_at: :desc).page(params[:page])
   end
 
   def new

--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link'

--- a/app/views/kaminari/_gap.html.slim
+++ b/app/views/kaminari/_gap.html.slim
@@ -1,0 +1,2 @@
+li.page-item.disabled
+  = link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link'

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link'

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link'

--- a/app/views/kaminari/_page.html.slim
+++ b/app/views/kaminari/_page.html.slim
@@ -1,0 +1,6 @@
+- if page.current?
+  li.page-item.active
+    = content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link'
+- else
+  li.page-item
+    = link_to page, url, remote: remote, rel: page.rel, class: 'page-link'

--- a/app/views/kaminari/_paginator.html.slim
+++ b/app/views/kaminari/_paginator.html.slim
@@ -1,0 +1,12 @@
+= paginator.render do
+  nav
+    ul.pagination
+      == first_page_tag unless current_page.first?
+      == prev_page_tag unless current_page.first?
+      - each_page do |page|
+        - if page.left_outer? || page.right_outer? || page.inside_window?
+          == page_tag page
+        - elsif !page.was_truncated?
+          == gap_tag
+      == next_page_tag unless current_page.last?
+      == last_page_tag unless current_page.last?

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link'

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -4,6 +4,7 @@
       / eachで回すよりパフォーマンスがよい
       / https://pikawaka.com/rails/partial_template
       = render @posts
+      = paginate @posts
     .col-md-4.col-12
       - if logged_in?
         .profile-box.mb-3

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 Kaminari.configure do |config|
-  # config.default_per_page = 25
+  # ページあたり表示数を10件とする
+  # ryotaさんのブログが参考になった
+  # [【Rails】kaminariを使用してページネーション機能を実装 \- Qiita](https://qiita.com/ryota21/items/29fa282745afb1474059#設定ファイルの説明)
+
+  config.default_per_page = 15
   # config.max_per_page = nil
   # config.window = 4
   # config.outer_window = 0

--- a/config/locales/kaminari_ja.yml
+++ b/config/locales/kaminari_ja.yml
@@ -1,0 +1,8 @@
+ja:
+  views:
+    pagination:
+      first: "<<"
+      last: ">>"
+      previous: "<"
+      next: ">"
+      truncate: "..."


### PR DESCRIPTION
## 作業ノート
- [Rails特訓コース Issue03ノート](https://github.com/miketa-webprgr/TIL/blob/master/11_Rails_Intensive_Training/03_issue_note.md)

## 実装内容

ページネーションにはkaminariを使用する（1ページあたり15件とする）
ページネーションにもbootstrapを適用する
ページネーションの国際化（nextを「>」に変更するなど）

## 確認方法
1. `git clone https://github.com/miketa-webprgr/instagram_clone.git`
2. `git checkout git checkout -b feature/01_login_logout origin/feature/01_login_logout`
3. `bundle install`
4. `yarn install`
5. `MySQL と Redis を立ち上げる`
6. `rails db:migrate`
7. `rails db:seed`

## コメント
- kaminariの実装は簡単だった
- 非同期にもチャレンジしたが、あきらめた
  - JSの知識があれば簡単そうだったので、いずれチャレンジしたいと感じた