### PR TITLE
07 投稿の検索機能の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,24 @@
 class ApplicationController < ActionController::Base
+  before_action :set_search_posts_value
+
   # notice, alert 以外のflashメッセージを使いたい場合、指定する必要がある
   add_flash_types :success, :info, :warning, :danger
+
+  private
 
   # sorceryのメソッド（デフォルトでは、required_loginがfalseの場合にはルートパスにアクセスさせる）
   # 上書きすることにより、指定のパス自体は変わらないが、「ログインしてください」というメッセージを出すことができる
   def not_authenticated
     redirect_to login_path, warning: 'ログインしてください'
+  end
+
+  # 検索ワードを残すメソッド
+  def set_search_posts_value
+    @search_value = search_post_params[:body]
+  end
+
+  def search_post_params
+    # params.fetch(:q, {})はparams[:q]が空の場合{}を、params[:q]が空でない場合はparams[:q]を返してくれる
+    params.fetch(:q, {}).permit(:body)
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -72,10 +72,21 @@ class PostsController < ApplicationController
     redirect_to posts_path, success: '投稿を削除しました'
   end
 
+  # 検索結果を表示させるアクション
+  # body_containメソッドはPostモデルにてscopeを定義した
+  def search
+    @posts = Post.body_contain(search_post_params[:body]).page(params[:page])
+  end
+
   private
 
   def post_params
     # images:[]とすることで、JSON形式でparamsを受け取る
     params.require(:post).permit(:body, images: [])
+  end
+
+  def search_post_params
+    # params.fetch(:q, {})はparams[:q]が空の場合{}を、params[:q]が空でない場合はparams[:q]を返してくれる
+    params.fetch(:q, {}).permit(:body)
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -75,7 +75,7 @@ class PostsController < ApplicationController
   # 検索結果を表示させるアクション
   # body_containメソッドはPostモデルにてscopeを定義した
   def search
-    @posts = Post.body_contain(search_post_params[:body]).page(params[:page])
+    @posts = Post.body_contain(search_post_params[:body]).includes(:user).page(params[:page])
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -74,8 +74,9 @@ class PostsController < ApplicationController
 
   # 検索結果を表示させるアクション
   # body_containメソッドはPostモデルにてscopeを定義した
+  # @search_valueは、application_controller内にあるインスタンス変数（検索ワードが代入されている）
   def search
-    @posts = Post.body_contain(search_post_params[:body]).includes(:user).page(params[:page])
+    @posts = Post.body_contain(@search_value).includes(:user).page(params[:page])
   end
 
   private
@@ -85,8 +86,4 @@ class PostsController < ApplicationController
     params.require(:post).permit(:body, images: [])
   end
 
-  def search_post_params
-    # params.fetch(:q, {})はparams[:q]が空の場合{}を、params[:q]が空でない場合はparams[:q]を返してくれる
-    params.fetch(:q, {}).permit(:body)
-  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -18,6 +18,11 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Post < ApplicationRecord
+  # [概要] Post.body_contain(だいそん)と書くと、投稿のbodyカラムに「だいそん」が含まれる投稿を検索してくれる
+  # [->とは] このマークはラムダであり、メソッドをオブジェクト化するものらしい（後ほどチェリー本できちんと勉強したい）
+  # [？の意味] クエスチョンマークはプレースホルダーというらしく、SQLインジェクトション対策で使うらしい（？を使わない直書きはNG）
+  scope :body_contain, ->(word) { where('body LIKE ?', "%#{word}%") }
+
   mount_uploaders :images, ImageUploader
   # 複数の画像を取り扱う場合、serializeメソッドが必要
   # JSON形式でなくとも、複数の画像を受け取ることは可能

--- a/app/views/posts/_search_form.html.slim
+++ b/app/views/posts/_search_form.html.slim
@@ -1,0 +1,4 @@
+/ だいそんさんのコードでは、model: search_form というオプションもあったが不要だと思われたので削除
+= form_with url: search_posts_path, method: :get, scope: :q, class: 'form-inline my-2 my-lg-0 mr-auto', local: true do |f|
+  = f.search_field :body, class: 'form-control mr-sm-2', placeholder: '本文'
+  = f.submit 'Search', class: 'btn btn-outline-success my-2 my-sm-0'

--- a/app/views/posts/_search_form.html.slim
+++ b/app/views/posts/_search_form.html.slim
@@ -1,4 +1,3 @@
-/ だいそんさんのコードでは、model: search_form というオプションもあったが不要だと思われたので削除
 = form_with url: search_posts_path, method: :get, scope: :q, class: 'form-inline my-2 my-lg-0 mr-auto', local: true do |f|
-  = f.search_field :body, class: 'form-control mr-sm-2', placeholder: '本文'
+  = f.search_field :body, class: 'form-control mr-sm-2', placeholder: '本文', value: search_value
   = f.submit 'Search', class: 'btn btn-outline-success my-2 my-sm-0'

--- a/app/views/posts/search.html.slim
+++ b/app/views/posts/search.html.slim
@@ -1,0 +1,7 @@
+.container
+  .row
+    .col-md-8.col-12.offset-md-2
+      h2.text-center
+        | 検索結果: #{@posts.total_count}件
+      = render @posts
+      = paginate @posts

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -2,10 +2,9 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-info
   = link_to 'InstaClone', root_path, class: 'navbar-brand'
   button.navbar-toggler aria-controls="navbarTogglerDemo02" aria-expanded="false" aria-label=("Toggle navigation") data-target="#navbarTogglerDemo02" data-toggle="collapse" type="button"
     span.navbar-toggler-icon
+    / 検索フォーム
   #navbarTogglerDemo02.collapse.navbar-collapse
-    form.form-inline.my-2.my-lg-0.mr-auto
-      input.form-control.mr-sm-2 placeholder="Search" type="search" /
-      button.btn.btn-outline-dark.my-2.my-sm-0 type="submit"  Search
+    = render 'posts/search_form', search_form: @search_form
     ul.navbar-nav.mt-2.mt-lg-0
       li.nav-item
         = link_to new_post_path, class: 'nav-link' do

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -2,9 +2,9 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-info
   = link_to 'InstaClone', root_path, class: 'navbar-brand'
   button.navbar-toggler aria-controls="navbarTogglerDemo02" aria-expanded="false" aria-label=("Toggle navigation") data-target="#navbarTogglerDemo02" data-toggle="collapse" type="button"
     span.navbar-toggler-icon
-    / 検索フォーム
   #navbarTogglerDemo02.collapse.navbar-collapse
-    = render 'posts/search_form', search_form: @search_form
+    / 検索フォーム
+    = render 'posts/search_form', search_value: @search_value
     ul.navbar-nav.mt-2.mt-lg-0
       li.nav-item
         = link_to new_post_path, class: 'nav-link' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,10 @@ Rails.application.routes.draw do
   # shallowオプションを使うと、一意にリソースを示しつつ、URLを短くすることができる。
   # 一意であることを諦めるのであれば、「resources :posts, shallow: true do」とすることもできる。
   resources :posts do
+    # RESTfulな７つのアクションに対して、searchという８つ目のアクションを追加する
+    # collectionは、リソース全体に対して追加するアクション（生成されるURLは、posts/search）
+    # memberは、特定のリソースに対して追加するアクション（生成されるURLは、post/:id/search）
+    get :search, on: :collection
     resources :comments, shallow: true
   end
 


### PR DESCRIPTION
## 作業ノート
- [Rails特訓コース Issue07ノート](https://github.com/miketa-webprgr/TIL/blob/master/11_Rails_Intensive_Training/07_issue_note.md)

## 実装内容

- 全ての投稿を検索対象とした検索フォームを実装する（フィードに対する検索ではない）
- 検索条件としては「投稿のbodyに検索ワードが含まれている投稿」とする
- ransackなどの検索用のGemは使わず、フォームオブジェクト、ActiveModelを使って実装すること
  - 最終的に、フォームオブジェクトとActiveModelを使わないこととした
  - [TechEssentialsでした質問](https://tech-essentials.work/questions/94)
- 検索時のパスは`/posts/search`とすること

## 確認方法
1. `git clone https://github.com/miketa-webprgr/instagram_clone.git`
2. `git checkout git checkout -b feature/07_search origin/feature/07_search`
3. `bundle install`
4. `yarn install`
5. `MySQL と Redis を立ち上げる`
6. `rails db:migrate`
7. `rails db:seed`

## コメント
- フォームオブジェクトの理解に時間がかかった
- フォームオブジェクトを使って、postsテーブルのbodyとcommentsテーブルのbodyから検索できるような機能の実装についても検討したが、そういった場合であっても、postsモデルに書いてしまった方がよいような気がしたので、見送ることにした