### PR TITLE
08 ユーザーの詳細ページに投稿一覧を表示する

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -97,3 +97,26 @@ img {
   justify-content: center;
 }
 
+.thumbs {
+  width: 100%;
+  position: relative;
+  display: block;
+
+  // 擬似要素を追加できる
+  // 空の要素を追加し、その要素で埋め尽くす
+  &::before {
+    content: "";
+    display: block;
+    padding-top: 100%;
+  }
+
+  // absoluteにより、擬似要素を覆うような形にしている
+  // object-fitを使うと、中央からいい感じにトリミングしてくれる
+  img {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    object-fit: cover;
+  }
+}

--- a/app/views/posts/_thumbnail_post.html.slim
+++ b/app/views/posts/_thumbnail_post.html.slim
@@ -1,0 +1,3 @@
+.col-md-4.mb-3
+  = link_to post_path(thumbnail_post), class: 'thumbs' do
+    = image_tag thumbnail_post.images.first.url

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -13,7 +13,7 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-info
         a.nav-link href="#"
           = icon 'far', 'heart', class: 'fa-lg'
       li.nav-item
-        a.nav-link href="#"
+        = link_to user_path(current_user), class: 'nav-link' do
           = icon 'far', 'user', class: 'fa-lg'
       li.nav-item
         = link_to 'ログアウト', logout_path, class: 'nav-link', method: :delete

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,6 +1,6 @@
 .container
   .row
-    .col-md-6.offset-md-3
+    .col-md-10.offset-md-1
       .card
         .card-body
           .text-center.mb-3

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -9,3 +9,6 @@
             = @user.username
           .text-center
             = render 'follow_area', user: @user
+          hr
+          .row
+            = render partial: 'posts/thumbnail_post', collection: @user.posts


### PR DESCRIPTION
## 作業ノート
- [Rails特訓コース Issue08ノート](https://github.com/miketa-webprgr/TIL/blob/master/11_Rails_Intensive_Training/08_issue_note.md)

## 実装内容

- ユーザーの詳細ページで同ユーザーの投稿を一覧表示させる
- 投稿写真のサムネイルをクリックすると、該当の投稿ページにアクセスできる
- ヘッダーのユーザーアイコンをクリックすると、自分のユーザー詳細ページにアクセスできる

## 確認方法
1. `git clone https://github.com/miketa-webprgr/instagram_clone.git`
2. `git checkout git checkout -b feature/07_search origin/feature/08_my_posts`
3. `bundle install`
4. `yarn install`
5. `MySQL と Redis を立ち上げる`
6. `rails db:migrate`
7. `rails db:seed`

## コメント
- 比較的簡単だったが、renderなどの良い復習になった
- 他の方も言っているように、cssのテクニックは難しかった。調べると1つ1つの意味は分かったが、なぜそのような組み合わせで、いい感じにトリミングしたタイルを並べることができるのか、いまいち分かっていない。