### PR TITLE
12 メールのジョブの永続化を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ gem 'carrierwave'
 gem 'faker'
 gem 'kaminari'
 gem 'config'
+gem 'sidekiq'
+gem 'sinatra'
 
 # NGワードの投稿を禁止するために導入。設定方法は以下を参照。
 # https://github.com/joshbuddy/swearjar

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
     config (2.2.1)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
+    connection_pool (2.2.3)
     crass (1.0.6)
     debug_inspector (0.0.3)
     deep_merge (1.2.1)
@@ -178,6 +179,8 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
     mysql2 (0.5.3)
     nio4r (2.5.2)
     nokogiri (1.10.10)
@@ -204,6 +207,8 @@ GEM
     public_suffix (4.0.6)
     puma (3.12.6)
     rack (2.2.3)
+    rack-protection (2.1.0)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.4.3)
@@ -275,6 +280,7 @@ GEM
     ruby-progressbar (1.10.1)
     ruby-vips (2.0.17)
       ffi (~> 1.9)
+    ruby2_keywords (0.0.2)
     ruby_dep (1.5.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -289,6 +295,15 @@ GEM
       tilt (>= 1.1, < 3)
     sassc (2.4.0)
       ffi (~> 1.9)
+    sidekiq (6.1.2)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
     slim (4.1.0)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -359,6 +374,8 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   sass-rails (~> 5.0)
+  sidekiq
+  sinatra
   slim-rails
   sorcery
   spring

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,16 +41,14 @@ module InstaClone
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}').to_s]
 
+    # カスタムバリデータを使用する
+    config.autoload_paths += Dir["#{config.root}/app/validators"]
+
     # generateコマンド時に生成されるファイルに制限をかける
     config.generators do |g|
       g.assets false # CSS, JSが自動生成されない
       g.test_framework false # Minitestが自動生成されない
       g.skip_routes true # ルーティングが自動生成されない
-    end
-
-    # カスタムバリデータを使用する
-    class Application < Rails::Application
-      config.autoload_paths += Dir["#{config.root}/app/validators"]
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,6 +44,9 @@ module InstaClone
     # カスタムバリデータを使用する
     config.autoload_paths += Dir["#{config.root}/app/validators"]
 
+    # バックグラウンドでキューを処理するサーバーとしてsidekiqを指定
+    config.active_job.queue_adapter = :sidekiq
+
     # generateコマンド時に生成されるファイルに制限をかける
     config.generators do |g|
       g.assets false # CSS, JSが自動生成されない

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,11 @@
+Sidekiq.configure_server do |config|
+  config.redis = {
+      url: 'redis://localhost:6379'
+  }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = {
+      url: 'redis://localhost:6379'
+  }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,6 @@
+# Sidekiqのダッシュボード導入のために必要
+require 'sidekiq/web'
+
 Rails.application.routes.draw do
   # ログインの有無にかかわらず、まず投稿一覧にアクセスする仕様にした（だいそんさんに合わせた）
   root 'posts#index'
@@ -32,6 +35,10 @@ Rails.application.routes.draw do
     resources :notifications, only: %i[index]
   end
 
-  # LetterOpenerWebのルーティングを設定する
-  mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
+  if Rails.env.development?
+    # LetterOpenerWebのルーティングを設定する
+    mount LetterOpenerWeb::Engine, at: '/letter_opener'
+    # Sidekiqのダッシュボードを設定する
+    mount Sidekiq::Web, at: '/sidekiq'
+  end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,4 @@
+:concurrency: 25
+:queues:
+  - default
+  - mailers


### PR DESCRIPTION
## 作業ノート
- [Rails特訓コース Issue12ノート](https://github.com/miketa-webprgr/TIL/blob/master/11_Rails_Intensive_Training/12_issue_note.md)

## 求められている機能実装・実装条件について

- メールのジョブを永続化させる
  - ActiveJobのアダプターにはsidekiqを利用する
  - ダッシュボード用にsinatraもインストールする

## 確認方法
1. `git clone https://github.com/miketa-webprgr/instagram_clone.git`
2. `git checkout git checkout -b feature/11_mail_on_activity origin/feature/11_mail_on_activity`
3. `bundle install`
4. `yarn install`
5. `MySQL と Redis を立ち上げる`
6. `bundle exec sidekiq -C config/sidekiq.yml`
7. `rails db:migrate`
8. `rails db:seed`
9.  フォロー等を操作して通知作成・メール送信のコールバックを作動させる必要あり 
10. `http://localhost:3000/letter_opener`にアクセス
11. `http://localhost:3000/sidekiq`にアクセス

## コメント
- 自画自賛するのもなんですが、今回はSidekiqについて相当調べたノートを作りましたよ

```rb
Sidekiq.❨╯°□°❩╯︵┻━┻
=> Calm down, yo.
```