### PR TITLE
13 通知の設定を実装

### DIFF
--- a/app/controllers/mypage/notification_settings_controller.rb
+++ b/app/controllers/mypage/notification_settings_controller.rb
@@ -4,5 +4,18 @@ class Mypage::NotificationSettingsController < Mypage::BaseController
   end
 
   def update
+    @user = User.find(current_user.id)
+    if @user.update(notification_settings_params)
+      redirect_to edit_mypage_notification_setting_path, success: 'メール通知設定を更新しました'
+    else
+      flash.now['danger'] = 'メール通知設定の更新に失敗しました'
+      render :edit
+    end
+  end
+
+  private
+
+  def notification_settings_params
+    params.require(:user).permit(:notification_on_comment, :notification_on_like, :notification_on_follow)
   end
 end

--- a/app/controllers/mypage/notification_settings_controller.rb
+++ b/app/controllers/mypage/notification_settings_controller.rb
@@ -1,0 +1,7 @@
+class Mypage::NotificationSettingsController < Mypage::BaseController
+  def edit
+  end
+
+  def update
+  end
+end

--- a/app/controllers/mypage/notification_settings_controller.rb
+++ b/app/controllers/mypage/notification_settings_controller.rb
@@ -1,5 +1,6 @@
 class Mypage::NotificationSettingsController < Mypage::BaseController
   def edit
+    @user = User.find(current_user.id)
   end
 
   def update

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -53,4 +53,9 @@ class Comment < ApplicationRecord
   def send_notification_mail
     UserMailer.with(user_from: user, user_to: post.user, comment: self).comment_post.deliver_later
   end
+
+  # ダックタイピングのため、overrideする
+  def send_mail?
+    user.notification_on_comment
+  end
 end

--- a/app/models/concerns/notifiable.rb
+++ b/app/models/concerns/notifiable.rb
@@ -12,7 +12,8 @@ module Notifiable
     # after_create_commitは、after_commitのエイリアスメソッド
     # after_saveというメソッドもあるが、こちらはDBにsaveする直前に発火するメソッド
     # DBの制約に抵触して保存できない場合も考慮して、after_create_commitとする
-    after_create_commit :create_notifications, :send_notification_mail
+    after_create_commit :create_notifications
+    after_create_commit :send_notification_mail, if: :send_mail?
   end
 
   def partial_name
@@ -30,6 +31,10 @@ module Notifiable
   end
 
   def send_notification_mail
+    raise NotImplementedError
+  end
+
+  def send_mail?
     raise NotImplementedError
   end
 end

--- a/app/models/concerns/notifiable.rb
+++ b/app/models/concerns/notifiable.rb
@@ -13,6 +13,7 @@ module Notifiable
     # after_saveというメソッドもあるが、こちらはDBにsaveする直前に発火するメソッド
     # DBの制約に抵触して保存できない場合も考慮して、after_create_commitとする
     after_create_commit :create_notifications
+    # 条件付きコールバックを実装してみた
     after_create_commit :send_notification_mail, if: :send_mail?
   end
 

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -49,4 +49,9 @@ class Like < ApplicationRecord
   def send_notification_mail
     UserMailer.with(user_from: user, user_to: post.user, post: post).like_post.deliver_later
   end
+
+  # ダックタイピングのため、overrideする
+  def send_mail?
+    user.notification_on_like
+  end
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -48,4 +48,9 @@ class Relationship < ApplicationRecord
   def send_notification_mail
     UserMailer.with(user_from: follower, user_to: followed).follow.deliver_later
   end
+
+  # ダックタイピングのため、overrideする
+  def send_mail?
+    followed.notification_on_follow
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,14 +2,17 @@
 #
 # Table name: users
 #
-#  id               :bigint           not null, primary key
-#  avatar           :string(255)
-#  crypted_password :string(255)
-#  email            :string(255)      not null
-#  salt             :string(255)
-#  username         :string(255)      not null
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
+#  id                      :bigint           not null, primary key
+#  avatar                  :string(255)
+#  crypted_password        :string(255)
+#  email                   :string(255)      not null
+#  notification_on_comment :boolean          default(TRUE)
+#  notification_on_follow  :boolean          default(TRUE)
+#  notification_on_like    :boolean          default(TRUE)
+#  salt                    :string(255)
+#  username                :string(255)      not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #
 # Indexes
 #

--- a/app/views/mypage/notification_settings/edit.html.slim
+++ b/app/views/mypage/notification_settings/edit.html.slim
@@ -1,6 +1,10 @@
 = form_with model: @user, url: mypage_notification_setting_path, method: :patch, local: true do |f|
   = render 'shared/error_messages', object: @user
   .form-group
+    / 今回は、ビューの実装にもこだわって、ほぼ回答を見るなくチャレンジしました
+    / BMDのサイトを参考にして、checkboxクラスをあててみました（ただ、微妙ですね。。。特に文字が半透明になるのが。。。）
+    / https://fezvrasta.github.io/bootstrap-material-design/docs/4.0/material-design/forms/
+    / 実装後の参考画像：https://i.gyazo.com/08c66a511091d974219eaa474fe404f8.png
     .checkbox 
       = f.check_box :notification_on_comment
       = f.label :notification_on_comment

--- a/app/views/mypage/notification_settings/edit.html.slim
+++ b/app/views/mypage/notification_settings/edit.html.slim
@@ -1,16 +1,14 @@
 = form_with model: @user, url: mypage_notification_setting_path, method: :patch, local: true do |f|
   = render 'shared/error_messages', object: @user
   .form-group
-    = f.check_box :notification_on_comment
-    = f.label :notification_on_comment
-
-  .form-group
-    = f.check_box :notification_on_like
-    = f.label :notification_on_like
-
-  .form-group
-    = f.check_box :notification_on_follow
-    = f.label :notification_on_follow
-
+    .checkbox 
+      = f.check_box :notification_on_comment
+      = f.label :notification_on_comment
+    .checkbox 
+      = f.check_box :notification_on_like
+      = f.label :notification_on_like
+    .checkbox 
+      = f.check_box :notification_on_follow
+      = f.label :notification_on_follow
   = f.submit class: 'btn btn-primary btn-raised'
   

--- a/app/views/mypage/notification_settings/edit.html.slim
+++ b/app/views/mypage/notification_settings/edit.html.slim
@@ -1,2 +1,16 @@
-h1 NotificationSettings#edit
-p Find me in app/views/notification_settings/edit.html.slim
+= form_with model: @user, url: mypage_notification_setting_path, method: :patch, local: true do |f|
+  = render 'shared/error_messages', object: @user
+  .form-group
+    = f.check_box :notification_on_comment
+    = f.label :notification_on_comment
+
+  .form-group
+    = f.check_box :notification_on_like
+    = f.label :notification_on_like
+
+  .form-group
+    = f.check_box :notification_on_follow
+    = f.label :notification_on_follow
+
+  = f.submit class: 'btn btn-primary btn-raised'
+  

--- a/app/views/mypage/notification_settings/edit.html.slim
+++ b/app/views/mypage/notification_settings/edit.html.slim
@@ -1,0 +1,2 @@
+h1 NotificationSettings#edit
+p Find me in app/views/notification_settings/edit.html.slim

--- a/app/views/mypage/shared/_sidebar.html.slim
+++ b/app/views/mypage/shared/_sidebar.html.slim
@@ -6,3 +6,6 @@ nav
     li
       = link_to '通知一覧', mypage_notifications_path
       hr
+    li
+      = link_to '通知設定', edit_mypage_notification_setting_path
+      hr

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,11 +1,11 @@
 Sidekiq.configure_server do |config|
   config.redis = {
-      url: 'redis://localhost:6379'
+    url: 'redis://localhost:6379'
   }
 end
 
 Sidekiq.configure_client do |config|
   config.redis = {
-      url: 'redis://localhost:6379'
+    url: 'redis://localhost:6379'
   }
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,6 +11,9 @@ ja:
         password_confirmation: 'パスワード確認'
         username: 'ユーザー名'
         avatar: 'アバター'
+        notification_on_comment: 'コメントがあった時に通知する'
+        notification_on_like: 'いいねされた時に通知する'
+        notification_on_follow: 'フォローされた時に通知する'
       post:
         images: '画像'
         body: '本文'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
     resource :account, only: %i[edit update]
     # プロフィール編集に関するアクションなので、indexアクションはmypageディレクトリ下にネストさせた
     resources :notifications, only: %i[index]
+    resource :notification_setting, only: %i[edit update]
   end
 
   if Rails.env.development?

--- a/db/migrate/20201003100138_add_notification_flags_to_users.rb
+++ b/db/migrate/20201003100138_add_notification_flags_to_users.rb
@@ -1,0 +1,7 @@
+class AddNotificationFlagsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :notification_on_comment, :boolean, default: true
+    add_column :users, :notification_on_like, :boolean, default: true
+    add_column :users, :notification_on_follow, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_28_013319) do
+ActiveRecord::Schema.define(version: 2020_10_03_100138) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "body", null: false
@@ -70,6 +70,9 @@ ActiveRecord::Schema.define(version: 2020_08_28_013319) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "avatar"
+    t.boolean "notification_on_comment", default: true
+    t.boolean "notification_on_like", default: true
+    t.boolean "notification_on_follow", default: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end


### PR DESCRIPTION
## 作業ノート
- [Rails特訓コース Issue13ノート](https://github.com/miketa-webprgr/TIL/blob/master/11_Rails_Intensive_Training/13_issue_note.md)

## 求められている機能実装・実装条件について

マイページに通知設定というメニューを追加する。  
設定画面から、以下のオンオフを切り替えられるようにする。  

- コメント時の通知メール
- いいね時の通知メール
- フォロー時の通知メール

## 確認方法
1. `git clone https://github.com/miketa-webprgr/instagram_clone.git`
2. `git checkout git checkout -b feature/11_mail_on_activity origin/feature/11_mail_on_activity`
3. `bundle install`
4. `yarn install`
5. `MySQL と Redis を立ち上げる`
6. `bundle exec sidekiq -C config/sidekiq.yml`
7. `rails db:migrate`
8. `rails db:seed`
9.  フォロー等を操作して通知作成・メール送信のコールバックを作動させる必要あり 
10. `http://localhost:3000/letter_opener`にアクセス

## コメント

- メール通知について、だいそんさんと異なってコールバックで発動するような実装となっています。
- よって、通知判定のロジックはモデル側で書いています。
- ダックタイピングにより、`send_mail?`メソッドを上書きする形で実装しています。
- 今回のケースはだいそんさんのコードを見ることなく実装できそうと思えるようになった。
  - 個人アプリ開発の経験が生きているのか、自分で大まかな流れがイメージできるようになってきた。

